### PR TITLE
Ignore vs code generating files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -258,6 +258,9 @@ paket-files/
 # CodeRush
 .cr/
 
+# Visual Studio Code
+.vscode/
+
 # Python Tools for Visual Studio (PTVS)
 __pycache__/
 *.pyc


### PR DESCRIPTION
When we are using Visual Studio Code and C# extension for it, it generates files within folder /.vscode .

As we want to ignore all files from "popular add-ons", we need to ignore this folder, or if we don't want to ignore it we need to add files /.vscode/launch.json and /.vscode/tasks.json to the solution.