### PR TITLE
Fix comments wording

### DIFF
--- a/src/Views/Blog/Post.cshtml
+++ b/src/Views/Blog/Post.cshtml
@@ -39,7 +39,7 @@
         }
 
         <a href="@Model.GetLink()#comments" itemprop="discussionUrl" title="Go to the comments section">
-            <span itemprop="commentCount">@Model.Comments.Count</span> comments
+            <span itemprop="commentCount">@Model.Comments.Count</span> @(Model.Comments.Count == 1 ? "comment" : "comments")
         </a>
 
         <meta itemprop="author" content="@settings.Value.Owner" />


### PR DESCRIPTION
If number of comments == 1, use 'comment' i.e. 1 comment
if number of comments != 1, use 'comments' i.e. 0 comments or 2 comments

Fixes #42