### PR TITLE
make slug field required

### DIFF
--- a/src/Models/Post.cs
+++ b/src/Models/Post.cs
@@ -15,6 +15,7 @@ namespace Miniblog.Core.Models
         [Required]
         public string Title { get; set; }
 
+        [Required]
         public string Slug { get; set; }
 
         [Required]


### PR DESCRIPTION
This will fix https://github.com/madskristensen/Miniblog.Core/issues/49 but it does require the use to supply a slug. 