### PR TITLE
remove redundant line causing NullReferenceException when slug is empty

### DIFF
--- a/src/Controllers/BlogController.cs
+++ b/src/Controllers/BlogController.cs
@@ -104,7 +104,6 @@ namespace Miniblog.Core.Controllers
 
             existing.Categories = categories.Split(",", StringSplitOptions.RemoveEmptyEntries).Select(c => c.Trim().ToLowerInvariant()).ToList();
             existing.Title = post.Title.Trim();
-            existing.Slug = post.Slug.Trim();
             existing.Slug = !string.IsNullOrWhiteSpace(post.Slug) ? post.Slug.Trim() : Models.Post.CreateSlug(post.Title);
             existing.IsPublished = post.IsPublished;
             existing.Content = post.Content.Trim();


### PR DESCRIPTION
This removes an unnecessary line, as the line following does the null check properly.

Addresses #49 without marking Slug as required.