### PR TITLE
Upgrade to .Net Core 2.1

### DIFF
--- a/src/Miniblog.Core.csproj
+++ b/src/Miniblog.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Miniblog.Core.csproj
+++ b/src/Miniblog.Core.csproj
@@ -8,8 +8,9 @@
     <PackageReference Include="Azure.ImageOptimizer" Version="1.1.0.39" />
     <PackageReference Include="LigerShark.WebOptimizer.Core" Version="1.0.197" />
     <PackageReference Include="LigerShark.WebOptimizer.Sass" Version="1.0.33-beta" />
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0" />
     <PackageReference Include="Microsoft.SyndicationFeed.ReaderWriter" Version="1.0.2" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.1.0" />
     <PackageReference Include="WebEssentials.AspNetCore.CdnTagHelpers" Version="1.0.16" />
     <PackageReference Include="WebEssentials.AspNetCore.OutputCaching" Version="1.0.16" />
     <PackageReference Include="WebEssentials.AspNetCore.PWA" Version="1.0.25" />

--- a/src/Miniblog.Core.csproj
+++ b/src/Miniblog.Core.csproj
@@ -18,8 +18,4 @@
     <PackageReference Include="WilderMinds.MetaWeblog" Version="1.2.3" />
   </ItemGroup>
 
-  <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.0" />
-  </ItemGroup>
-
 </Project>

--- a/src/Startup.cs
+++ b/src/Startup.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Rewrite;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -41,7 +42,8 @@ namespace Miniblog.Core
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddMvc();
+            services.AddMvc()
+                .SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
 
             services.AddSingleton<IUserServices, BlogUserServices>();
             services.AddSingleton<IBlogService, FileBlogService>();

--- a/src/Startup.cs
+++ b/src/Startup.cs
@@ -28,14 +28,13 @@ namespace Miniblog.Core
 
         public static void Main(string[] args)
         {
-            BuildWebHost(args).Run();
+            CreateWebHostBuilder(args).Build().Run();
         }
 
-        public static IWebHost BuildWebHost(string[] args) =>
+        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()
-                .UseKestrel(a => a.AddServerHeader = false)
-                .Build();
+                .UseKestrel(a => a.AddServerHeader = false);
 
         public IConfiguration Configuration { get; }
 

--- a/src/Startup.cs
+++ b/src/Startup.cs
@@ -125,7 +125,7 @@ namespace Miniblog.Core
 
             if (Configuration.GetValue<bool>("forcessl"))
             {
-                app.UseRewriter(new RewriteOptions().AddRedirectToHttps());
+                app.UseHttpsRedirection();
             }
 
             app.UseMetaWeblog("/metaweblog");

--- a/src/Startup.cs
+++ b/src/Startup.cs
@@ -109,15 +109,12 @@ namespace Miniblog.Core
             else
             {
                 app.UseExceptionHandler("/Shared/Error");
+                app.UseHsts();
             }
 
             app.Use((context, next) =>
             {
                 context.Response.Headers["X-Content-Type-Options"] = "nosniff";
-                if (context.Request.IsHttps)
-                {
-                    context.Response.Headers["Strict-Transport-Security"] = "max-age=63072000; includeSubDomains";
-                }
                 return next();
             });
 


### PR DESCRIPTION
This PR does some of the basic steps in upgrading to .NET Core 2.1, based on https://docs.microsoft.com/en-us/aspnet/core/migration/20_21?view=aspnetcore-2.1

- [x] Use new idiom exposing `IWebHostBuilder` instead of `IWebHost`
- [x] Use new `Microsoft.AspNetCore.App` NuGet package
- [x] Set MVC compatibility to 2.1
- [x] Replace HSTS implementation with new built-in middleware
- [x] Replace HTTPS redirection with new built-in middleware
  - [ ] [Always redirect to HTTPS](https://docs.microsoft.com/en-us/aspnet/core/security/enforcing-ssl?view=aspnetcore-2.1#require-https), rather than based on config
- [ ] [Implement GDPR cookie policy](https://docs.microsoft.com/en-us/aspnet/core/security/gdpr?view=aspnetcore-2.1)
- [ ] [Use Razor partials for login](https://docs.microsoft.com/en-us/aspnet/core/migration/20_21?view=aspnetcore-2.1#changes-to-authentication-code)

I'm sure you may know more details about some of these, but I hope this is a helpful start.