### PR TITLE
fix xml encoding in feeds response

### DIFF
--- a/src/Controllers/RobotsController.cs
+++ b/src/Controllers/RobotsController.cs
@@ -107,7 +107,7 @@ namespace Miniblog.Core.Controllers
             Response.ContentType = "application/xml";
             string host = Request.Scheme + "://" + Request.Host;
 
-            using (XmlWriter xmlWriter = XmlWriter.Create(Response.Body, new XmlWriterSettings() { Async = true, Indent = true }))
+            using (XmlWriter xmlWriter = XmlWriter.Create(Response.Body, new XmlWriterSettings() { Async = true, Indent = true, Encoding = new UTF8Encoding(false) }))
             {
                 var posts = await _blog.GetPosts(10);
                 var writer = await GetWriter(type, xmlWriter, posts.Max(p => p.PubDate));


### PR DESCRIPTION
The encoding must be set to remove the ? byte value (BOM) at the beginning of the response.
Encoding property is ignored if the XmlWriter is not using a Stream (so, no problem here) and using Encoding.UTF8 is not working.
We have to create our own instance of UTF8Encoding.