### PR TITLE
display owner value from settings in rss author tag

### DIFF
--- a/src/Controllers/RobotsController.cs
+++ b/src/Controllers/RobotsController.cs
@@ -129,7 +129,7 @@ namespace Miniblog.Core.Controllers
                         item.AddCategory(new SyndicationCategory(category));
                     }
 
-                    item.AddContributor(new SyndicationPerson(_settings.Value.Owner, "test@example.com"));
+                    item.AddContributor(new SyndicationPerson("test@example.com", _settings.Value.Owner));
                     item.AddLink(new SyndicationLink(new Uri(item.Id)));
 
                     await writer.Write(item);


### PR DESCRIPTION
test@example.com was set in author tag instead of owner value (https://madskristensen.net/feed/rss)
fix order of syndicationPerson params email/name as seen in doc  (https://msdn.microsoft.com/en-us/library/system.servicemodel.syndication.syndicationperson%28v=vs.110%29.aspx)