### PR TITLE
Fixed issue #64: New post doesn't work when in edit mode.

### DIFF
--- a/src/TagHelpers/NewPostTagHelper.cs
+++ b/src/TagHelpers/NewPostTagHelper.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.AspNetCore.Razor.TagHelpers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Miniblog.Core.TagHelpers
+{
+    [HtmlTargetElement("a", Attributes="new-post")]
+    public class NewPostTagHelper : TagHelper
+    {
+        public override void Process(TagHelperContext context, TagHelperOutput output)
+        {
+            output.Attributes.SetAttribute("asp-route-id", "0");
+            base.Process(context, output);
+        }
+    }
+}

--- a/src/Views/Shared/_Layout.cshtml
+++ b/src/Views/Shared/_Layout.cshtml
@@ -61,7 +61,7 @@
 
                         if (User.Identity.IsAuthenticated)
                         {
-                            <li><a asp-controller="Blog" asp-action="Edit">New post</a></li>
+                            <li><a asp-controller="Blog" asp-action="Edit" asp-route-id="">New post</a></li>
                             <li><a href="~/logout/" title="Sign out as administrator">Sign out</a></li>
                         }
                         else

--- a/src/Views/Shared/_Layout.cshtml
+++ b/src/Views/Shared/_Layout.cshtml
@@ -61,7 +61,7 @@
 
                         if (User.Identity.IsAuthenticated)
                         {
-                            <li><a asp-controller="Blog" asp-action="Edit" asp-route-id="">New post</a></li>
+                            <li><a asp-controller="Blog" asp-action="Edit" new-post>New post</a></li>
                             <li><a href="~/logout/" title="Sign out as administrator">Sign out</a></li>
                         }
                         else


### PR DESCRIPTION
Added asp-route-id="" tag helper to the new post tag to override the existing post id when user is in edit mode for an existing post.