### PR TITLE
fix Category page selector in url is not correct #69

### DIFF
--- a/src/Views/Blog/Post.cshtml
+++ b/src/Views/Blog/Post.cshtml
@@ -32,7 +32,7 @@
                 <li> Posted in </li>
                 @foreach (string cat in Model.Categories)
                 {
-                    <li itemprop="articleSection"><a asp-controller="Blog" asp-action="Category" asp-route-category="@cat.ToLowerInvariant()">@cat</a></li>
+                    <li itemprop="articleSection"><a asp-controller="Blog" asp-action="Category" asp-route-category="@cat.ToLowerInvariant()" asp-route-page="">@cat</a></li>
                 }
             </ul>
             <text>and has</text>


### PR DESCRIPTION
With this fix we have now always a link from the post paged view to category based post view and empty page elemnet on the route, so we start with the first page from lower named category.