### PR TITLE
fix against #76 open livewriter is not able to connect

### DIFF
--- a/src/Services/MetaWeblogService.cs
+++ b/src/Services/MetaWeblogService.cs
@@ -132,7 +132,7 @@ namespace Miniblog.Core.Services
 
             return new[] { new BlogInfo {
                 blogid ="1",
-                blogName = _config["blog:name"],
+                blogName = _config["blog:name"] ?? nameof(MetaWeblogService),
                 url = url
             }};
         }


### PR DESCRIPTION
open livewriter is not able to connect, gives an obscure error return,
normally the appsettings have now no name element anymore, so we give the service class name return, the user is able to change this retun in openlivewriter to his own label. 