### PR TITLE
fixes SaveFile not check for invalid chars #82

### DIFF
--- a/src/Services/FileBlogService.cs
+++ b/src/Services/FileBlogService.cs
@@ -1,27 +1,31 @@
-﻿using System;
+﻿using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Miniblog.Core.Models;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using System.Xml.XPath;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Http;
-using Miniblog.Core.Models;
 
 namespace Miniblog.Core.Services
 {
     public class FileBlogService : IBlogService
     {
+        private const string POSTS = "Posts";
+        private const string FILES = "files";
+
         private readonly List<Post> _cache = new List<Post>();
         private readonly IHttpContextAccessor _contextAccessor;
         private readonly string _folder;
 
         public FileBlogService(IHostingEnvironment env, IHttpContextAccessor contextAccessor)
         {
-            _folder = Path.Combine(env.WebRootPath, "Posts");
+            _folder = Path.Combine(env.WebRootPath, POSTS);
             _contextAccessor = contextAccessor;
 
             Initialize();
@@ -49,7 +53,6 @@ namespace Miniblog.Core.Services
                         select p;
 
             return Task.FromResult(posts);
-
         }
 
         public virtual Task<Post> GetPostBySlug(string slug)
@@ -160,13 +163,14 @@ namespace Miniblog.Core.Services
 
         public async Task<string> SaveFile(byte[] bytes, string fileName, string suffix = null)
         {
-            suffix = suffix ?? DateTime.UtcNow.Ticks.ToString();
+            suffix = CleanFromInvalidChars(suffix ?? DateTime.UtcNow.Ticks.ToString());
 
             string ext = Path.GetExtension(fileName);
-            string name = Path.GetFileNameWithoutExtension(fileName);
+            string name = CleanFromInvalidChars(Path.GetFileNameWithoutExtension(fileName));
 
-            string relative = $"files/{name}_{suffix}{ext}";
-            string absolute = Path.Combine(_folder, relative);
+            string fileNameWithSuffix = $"{name}_{suffix}{ext}";
+
+            string absolute = Path.Combine(_folder, FILES, fileNameWithSuffix);
             string dir = Path.GetDirectoryName(absolute);
 
             Directory.CreateDirectory(dir);
@@ -175,7 +179,7 @@ namespace Miniblog.Core.Services
                 await writer.WriteAsync(bytes, 0, bytes.Length).ConfigureAwait(false);
             }
 
-            return "/Posts/" + relative;
+            return $"/{POSTS}/{FILES}/{fileNameWithSuffix}";
         }
 
         private string GetFilePath(Post post)
@@ -271,6 +275,17 @@ namespace Miniblog.Core.Services
 
             return defaultValue;
         }
+
+        private static string CleanFromInvalidChars(string input)
+        {
+            // ToDo: what we are doing here if we switch the blog from windows
+            // to unix system or vice versa? we should remove all invalid chars for both systems
+
+            var regexSearch = Regex.Escape(new string(Path.GetInvalidFileNameChars()) + new string(Path.GetInvalidPathChars()));
+            var r = new Regex($"[{regexSearch}]");
+            return r.Replace(input, "");
+        }
+
         protected void SortCache()
         {
             _cache.Sort((p1, p2) => p2.PubDate.CompareTo(p1.PubDate));
@@ -280,6 +295,5 @@ namespace Miniblog.Core.Services
         {
             return _contextAccessor.HttpContext?.User?.Identity.IsAuthenticated == true;
         }
-
     }
 }


### PR DESCRIPTION
sometimes the file names or suffixes have invalid path names on blog hosted by operation system; also the relative pathname is used to create the absolute with hardcoded "/" - works only on windows

fixed with PR