### PR TITLE
Fix images saving as base64

### DIFF
--- a/src/Controllers/BlogController.cs
+++ b/src/Controllers/BlogController.cs
@@ -111,9 +111,9 @@ namespace Miniblog.Core.Controllers
             existing.Content = post.Content.Trim();
             existing.Excerpt = post.Excerpt.Trim();
 
-            await _blog.SavePost(existing);
-
             await SaveFilesToDisk(existing);
+
+            await _blog.SavePost(existing);
 
             return Redirect(post.GetEncodedLink());
         }


### PR DESCRIPTION
When saving a post, there is code to extract the base64 encoded images into files and update the post content to point to those newly saved files.  However, this runs after the blog post is saved, so the updates to the blog post's markup aren't persisted.  The files are correctly saved, but the post's markup still includes base64 encoded images.