### PR TITLE
Should be able to cancel post and create new post from edit view

### DIFF
--- a/src/Views/Blog/Edit.cshtml
+++ b/src/Views/Blog/Edit.cshtml
@@ -8,43 +8,45 @@
     <link rel="stylesheet" href="~/css/admin.scss" />
 }
 
-<form method="post" id="edit" class="container" asp-controller="Blog" asp-action="UpdatePost">
-    <div asp-validation-summary="All"></div>
-    <input type="hidden" asp-for="@Model.ID" />
+    <form method="post" id="edit" class="container" asp-controller="Blog" asp-action="UpdatePost">
+        <div asp-validation-summary="All"></div>
+        <input type="hidden" asp-for="@Model.ID" />
 
-    <label asp-for="@Model.Title" class="label">Title</label>
-    <input asp-for="@Model.Title" required placeholder="Title of blog post" aria-describedby="desc_title" />
-    <span class="desc" id="desc_title">The title as it appears on the website</span>
-    <br />
+        <label asp-for="@Model.Title" class="label">Title</label>
+        <input asp-for="@Model.Title" required placeholder="Title of blog post" aria-describedby="desc_title" />
+        <span class="desc" id="desc_title">The title as it appears on the website</span>
+        <br />
 
-    <label asp-for="@Model.Slug" class="label">Slug</label>
-    <input asp-for="@Model.Slug" placeholder="The URL name" aria-describedby="desc_slug" />
-    <span class="desc" id="desc_slug">The part of the URL that identifies this blog post</span>
-    <br />
+        <label asp-for="@Model.Slug" class="label">Slug</label>
+        <input asp-for="@Model.Slug" placeholder="The URL name" aria-describedby="desc_slug" />
+        <span class="desc" id="desc_slug">The part of the URL that identifies this blog post</span>
+        <br />
 
-    <label for="categories" class="label">Tags</label>
-    <input type="text" name="categories" id="categories" value="@string.Join(", ", Model.Categories)" aria-describedby="desc_categories" />
-    <span class="desc" id="desc_categories">A comma separated list of keywords</span>
-    <br />
+        <label for="categories" class="label">Tags</label>
+        <input type="text" name="categories" id="categories" value="@string.Join(", ", Model.Categories)" aria-describedby="desc_categories" />
+        <span class="desc" id="desc_categories">A comma separated list of keywords</span>
+        <br />
 
-    <label asp-for="@Model.Excerpt" class="label">Excerpt</label>
-    <textarea asp-for="@Model.Excerpt" rows="3" placeholder="Short description of blog post" aria-describedby="desc_excerpt">@Model.Excerpt</textarea>
-    <span class="desc" id="desc_excerpt">A brief description of the content of the post</span>
-    <br />
+        <label asp-for="@Model.Excerpt" class="label">Excerpt</label>
+        <textarea asp-for="@Model.Excerpt" rows="3" placeholder="Short description of blog post" aria-describedby="desc_excerpt">@Model.Excerpt</textarea>
+        <span class="desc" id="desc_excerpt">A brief description of the content of the post</span>
+        <br />
 
-    <textarea asp-for="@Model.Content" rows="20" aria-label="Content">@Model.Content</textarea>
-    <br />
-
-    <input type="submit" value="Save" title="Save the post" />
-
-    <input asp-for="@Model.IsPublished" />
-    <label asp-for="@Model.IsPublished">Is published</label>
-
-    @if (!isNew)
-    {
-        <input type="submit" value="Delete..." class="delete" title="Delete the post..." asp-action="DeletePost" asp-route-id="@Model.ID" />
-    }
-</form>
+        <textarea asp-for="@Model.Content" rows="20" aria-label="Content">@Model.Content</textarea>
+        <br />
+        <section style="text-align:left; max-width:30%; float:left;">
+            <a asp-controller="Blog" asp-action="Index">Cancel</a>
+            @if (!isNew)
+            {
+                <input type="submit" value="Delete" class="delete" title="Delete the post..." asp-action="DeletePost" asp-route-id="@Model.ID" />
+            }
+        </section>
+        <section style="text-align:right; max-width:30%; float:right;">
+            <input type="submit" value="Save" title="Save the post" />
+            <input asp-for="@Model.IsPublished" />
+            <label asp-for="@Model.IsPublished">Is published</label>
+        </section>
+    </form>
 
 @section Scripts {
     <script src="~/lib/tinymce/tinymce.min.js"></script>

--- a/src/Views/Shared/_Layout.cshtml
+++ b/src/Views/Shared/_Layout.cshtml
@@ -61,7 +61,7 @@
 
                         if (User.Identity.IsAuthenticated)
                         {
-                            <li><a asp-controller="Blog" asp-action="Edit">New post</a></li>
+                            <li><a asp-controller="Blog" asp-action="Edit" asp-route-id="">New post</a></li>
                             <li><a href="~/logout/" title="Sign out as administrator">Sign out</a></li>
                         }
                         else


### PR DESCRIPTION
Revert from using tag helper to create a new post from edit view. Added a cancel button in the absence of a clear way to navigate outside of edit/new post view without invoking an action. Users can navigate via the browser or the logo, however, it may not be intuitive to all.

This PR should replace #74.