### PR TITLE
Fix overly greedy Regex

### DIFF
--- a/src/Controllers/BlogController.cs
+++ b/src/Controllers/BlogController.cs
@@ -120,7 +120,7 @@ namespace Miniblog.Core.Controllers
 
         private async Task SaveFilesToDisk(Post post)
         {
-            var imgRegex = new Regex("<img[^>].+ />", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+            var imgRegex = new Regex("<img[^>]+ />", RegexOptions.IgnoreCase | RegexOptions.Compiled);
             var base64Regex = new Regex("data:[^/]+/(?<ext>[a-z]+);base64,(?<base64>.+)", RegexOptions.IgnoreCase);
             string[] allowedExtensions = new [] {
               ".jpg",


### PR DESCRIPTION
When trying to read base64 images from post content, extra content can be captured by the regex and replaced.  This can result in content mysteriously going missing, or from errors in the `LoadXml` call if there is HTML content in the post that isn't valid XML (e.g. `&rsquo;`)