### PR TITLE
Update fixes 'Older' (Previous) button from showing when no more pages to show

### DIFF
--- a/src/Views/Blog/Index.cshtml
+++ b/src/Views/Blog/Index.cshtml
@@ -2,6 +2,7 @@
 @inject IOptionsSnapshot<BlogSettings> settings
 @{
     int currentPage = int.Parse(ViewContext.RouteData.Values["page"] as string ?? "0");
+    int pageCount = Model.ToList().Count-1; 
 }
 
 @foreach (var post in Model)
@@ -10,7 +11,7 @@
 }
 
 <nav class="pagination container" aria-label="Pagination">
-    @if (Model.Any())
+    @if (Model.Any() && currentPage < pageCount)
     {
         <a rel="prev" href="@ViewData["prev"]" title="Older posts">&laquo; Older</a>
     }
@@ -21,7 +22,7 @@
     <br /><br />
 
     @section Head {
-        @if (Model.Any())
+        @if (Model.Any() && currentPage < pageCount)
         {
             <link rel="prev" href="@ViewData["prev"]" />
         }


### PR DESCRIPTION
Added the pageCount variable which calculates the total number of pages. When the current page is the last ACTUAL page, the Previous (older) button will no longer show up, and take the user to an empty page.