### PR TITLE
Fixed erroneous decrement

### DIFF
--- a/src/Views/Blog/Index.cshtml
+++ b/src/Views/Blog/Index.cshtml
@@ -2,6 +2,7 @@
 @inject IOptionsSnapshot<BlogSettings> settings
 @{
     int currentPage = int.Parse(ViewContext.RouteData.Values["page"] as string ?? "0");
+    int pageCount = Model.ToList().Count-1; 
 }
 
 @foreach (var post in Model)
@@ -10,7 +11,7 @@
 }
 
 <nav class="pagination container" aria-label="Pagination">
-    @if (Model.Any())
+    @if (Model.Any() && currentPage < pageCount)
     {
         <a rel="prev" href="@ViewData["prev"]" title="Older posts">&laquo; Older</a>
     }
@@ -21,7 +22,7 @@
     <br /><br />
 
     @section Head {
-        @if (Model.Any())
+        @if (Model.Any() && currentPage < pageCount)
         {
             <link rel="prev" href="@ViewData["prev"]" />
         }

--- a/src/Views/Blog/Index.cshtml
+++ b/src/Views/Blog/Index.cshtml
@@ -2,7 +2,7 @@
 @inject IOptionsSnapshot<BlogSettings> settings
 @{
     int currentPage = int.Parse(ViewContext.RouteData.Values["page"] as string ?? "0");
-    int pageCount = Model.ToList().Count-1; 
+    int pageCount = Model.ToList().Count;
 }
 
 @foreach (var post in Model)


### PR DESCRIPTION
Fixed an erroneous decrement which was meant to be removed before submitting previous PR:

Caused the 'Older' button to stop showing a page earlier than intended. 