### PR TITLE
Fix NETSDK1071 for Microsoft.AspNetCore.App

### DIFF
--- a/src/Miniblog.Core.csproj
+++ b/src/Miniblog.Core.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Azure.ImageOptimizer" Version="1.1.0.39" />
     <PackageReference Include="LigerShark.WebOptimizer.Core" Version="1.0.197" />
     <PackageReference Include="LigerShark.WebOptimizer.Sass" Version="1.0.33-beta" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.SyndicationFeed.ReaderWriter" Version="1.0.2" />
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.1.0" />
     <PackageReference Include="WebEssentials.AspNetCore.CdnTagHelpers" Version="1.0.16" />


### PR DESCRIPTION
Building the current master with `dotnet` v3.0.100 gives:

> warning NETSDK1071: A PackageReference to 'Microsoft.AspNetCore.App' specified a Version of `2.1.0`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs