### PR TITLE
Added asp-route-id="" attribute to the new post link which clears the existing slug in edit mode

### DIFF
--- a/src/Views/Shared/_Layout.cshtml
+++ b/src/Views/Shared/_Layout.cshtml
@@ -61,7 +61,7 @@
 
                         if (User.Identity.IsAuthenticated)
                         {
-                            <li><a asp-controller="Blog" asp-action="Edit">New post</a></li>
+                            <li><a asp-controller="Blog" asp-action="Edit" asp-route-id="">New post</a></li>
                             <li><a href="~/logout/" title="Sign out as administrator">Sign out</a></li>
                         }
                         else


### PR DESCRIPTION
This fix simply adds the asp-route-id="" attribute to the new post link in _Layout.cshtml. This clears the slug which causes the exiting post to load again.