### PR TITLE
Generate random slug in case user doesn't want to specify slug

### DIFF
--- a/src/Models/Post.cs
+++ b/src/Models/Post.cs
@@ -29,7 +29,7 @@ namespace Miniblog.Core.Models
 
         public DateTime PubDate { get; set; } = DateTime.UtcNow;
 
-        public string Slug { get; set; } = string.Empty;
+        public string Slug { get; set; } = GenerateRandomSlug();
 
         [Required]
         public string Title { get; set; } = string.Empty;
@@ -104,6 +104,21 @@ namespace Miniblog.Core.Models
             }
 
             return text;
+        }
+
+        private static string GenerateRandomSlug()
+        {
+            var chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+            var stringChars = new char[8];
+            var random = new Random();
+
+            for (int i = 0; i < stringChars.Length; i++)
+            {
+                stringChars[i] = chars[random.Next(chars.Length)];
+            }
+
+            var finalString = new String(stringChars);
+            return finalString;
         }
     }
 }


### PR DESCRIPTION
This will populate slug text box with random 8 char string when creating new post. Users can override this in the text box with their own custom slug if desired.