### PR TITLE
Fix bug if slug left empty then will be treated as null

### DIFF
--- a/src/Models/Post.cs
+++ b/src/Models/Post.cs
@@ -29,6 +29,7 @@ namespace Miniblog.Core.Models
 
         public DateTime PubDate { get; set; } = DateTime.UtcNow;
 
+        [DisplayFormat(ConvertEmptyStringToNull = false)]
         public string Slug { get; set; } = string.Empty;
 
         [Required]


### PR DESCRIPTION
Expected behavior is that site will generate slug based on title if slug left empty, however, error would occur that wouldn't allow you to save post because value was being treated as null.