### PR TITLE
Add support for tags

### DIFF
--- a/src/Constants.cs
+++ b/src/Constants.cs
@@ -5,7 +5,9 @@ namespace Miniblog.Core
     public static class Constants
     {
         public static readonly string AllCats = "AllCats";
+        public static readonly string AllTags = "AllTags";
         public static readonly string categories = "categories";
+        public static readonly string tags = "tags";
         public static readonly string Dash = "-";
         public static readonly string Description = "Description";
         public static readonly string Head = "Head";

--- a/src/Controllers/BlogController.cs
+++ b/src/Controllers/BlogController.cs
@@ -89,6 +89,27 @@ namespace Miniblog.Core.Controllers
             return this.View("~/Views/Blog/Index.cshtml", filteredPosts.AsAsyncEnumerable());
         }
 
+        [Route("/blog/tag/{tag}/{page:int?}")]
+        [OutputCache(Profile = "default")]
+        public async Task<IActionResult> Tag(string tag, int page = 0)
+        {
+            // get posts for the selected tag.
+            var posts = this.blog.GetPostsByTag(tag);
+
+            // apply paging filter.
+            var filteredPosts = posts.Skip(this.settings.Value.PostsPerPage * page).Take(this.settings.Value.PostsPerPage);
+
+            // set the view option
+            this.ViewData["ViewOption"] = this.settings.Value.ListView;
+
+            this.ViewData[Constants.TotalPostCount] = await posts.CountAsync().ConfigureAwait(true);
+            this.ViewData[Constants.Title] = $"{this.manifest.Name} {tag}";
+            this.ViewData[Constants.Description] = $"Articles posted in the {tag} tag";
+            this.ViewData[Constants.prev] = $"/blog/tag/{tag}/{page + 1}/";
+            this.ViewData[Constants.next] = $"/blog/tag/{tag}/{(page <= 1 ? null : page - 1 + "/")}";
+            return this.View("~/Views/Blog/Index.cshtml", filteredPosts.AsAsyncEnumerable());
+        }
+
         [Route("/blog/comment/{postId}/{commentId}")]
         [Authorize]
         public async Task<IActionResult> DeleteComment(string postId, string commentId)
@@ -134,6 +155,10 @@ namespace Miniblog.Core.Controllers
             var categories = await this.blog.GetCategories().ToListAsync();
             categories.Sort();
             this.ViewData[Constants.AllCats] = categories;
+
+            var tags = await this.blog.GetTags().ToListAsync();
+            tags.Sort();
+            this.ViewData[Constants.AllTags] = tags;
 
             if (string.IsNullOrEmpty(id))
             {
@@ -198,12 +223,18 @@ namespace Miniblog.Core.Controllers
 
             var existing = await this.blog.GetPostById(post.ID).ConfigureAwait(false) ?? post;
             string categories = this.Request.Form[Constants.categories];
+            string tags = this.Request.Form[Constants.tags];
 
             existing.Categories.Clear();
             categories.Split(",", StringSplitOptions.RemoveEmptyEntries)
                 .Select(c => c.Trim().ToLowerInvariant())
                 .ToList()
                 .ForEach(existing.Categories.Add);
+            existing.Tags.Clear();
+            tags.Split(",", StringSplitOptions.RemoveEmptyEntries)
+                .Select(t => t.Trim().ToLowerInvariant())
+                .ToList()
+                .ForEach(existing.Tags.Add);
             existing.Title = post.Title.Trim();
             existing.Slug = !string.IsNullOrWhiteSpace(post.Slug) ? post.Slug.Trim() : Models.Post.CreateSlug(post.Title);
             existing.IsPublished = post.IsPublished;

--- a/src/Controllers/RobotsController.cs
+++ b/src/Controllers/RobotsController.cs
@@ -111,6 +111,10 @@ namespace Miniblog.Core.Controllers
                 {
                     item.AddCategory(new SyndicationCategory(category));
                 }
+                foreach (var tag in post.Tags)
+                {
+                    item.AddCategory(new SyndicationCategory(tag));
+                }
 
                 item.AddContributor(new SyndicationPerson("test@example.com", this.settings.Value.Owner));
                 item.AddLink(new SyndicationLink(new Uri(item.Id)));

--- a/src/Miniblog.Core.csproj
+++ b/src/Miniblog.Core.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -23,7 +23,7 @@
     <PackageReference Include="WebEssentials.AspNetCore.PWA" Version="1.0.59" />
     <PackageReference Include="WebEssentials.AspNetCore.StaticFilesWithCache" Version="1.0.1" />
     <PackageReference Include="WebMarkupMin.AspNetCore2" Version="2.7.0" />
-    <PackageReference Include="WilderMinds.MetaWeblog" Version="2.0.1" />
+    <PackageReference Include="WilderMinds.MetaWeblog" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Models/Post.cs
+++ b/src/Models/Post.cs
@@ -12,6 +12,8 @@ namespace Miniblog.Core.Models
     {
         public IList<string> Categories { get; } = new List<string>();
 
+        public IList<string> Tags { get; } = new List<string>();
+
         public IList<Comment> Comments { get; } = new List<Comment>();
 
         [Required]

--- a/src/Services/FileBlogService.cs
+++ b/src/Services/FileBlogService.cs
@@ -84,6 +84,22 @@ namespace Miniblog.Core.Services
                 .ToAsyncEnumerable();
         }
 
+        [SuppressMessage(
+            "Globalization",
+            "CA1308:Normalize strings to uppercase",
+            Justification = "Consumer preference.")]
+        public virtual IAsyncEnumerable<string> GetTags()
+        {
+            var isAdmin = this.IsAdmin();
+
+            return this.cache
+                .Where(p => p.IsPublished || isAdmin)
+                .SelectMany(post => post.Tags)
+                .Select(tag => tag.ToLowerInvariant())
+                .Distinct()
+                .ToAsyncEnumerable();
+        }
+
         public virtual Task<Post?> GetPostById(string id)
         {
             var isAdmin = this.IsAdmin();
@@ -143,6 +159,18 @@ namespace Miniblog.Core.Services
             return posts.ToAsyncEnumerable();
         }
 
+        public IAsyncEnumerable<Post> GetPostsByTag(string tag)
+        {
+            var isAdmin = this.IsAdmin();
+
+            var posts = from p in this.cache
+                        where p.PubDate <= DateTime.UtcNow && (p.IsPublished || isAdmin)
+                        where p.Tags.Contains(tag, StringComparer.OrdinalIgnoreCase)
+                        select p;
+
+            return posts.ToAsyncEnumerable();
+        }
+
         [SuppressMessage(
             "Usage",
             "SecurityIntelliSenseCS:MS Security rules violation",
@@ -193,6 +221,7 @@ namespace Miniblog.Core.Services
                                 new XElement("content", post.Content),
                                 new XElement("ispublished", post.IsPublished),
                                 new XElement("categories", string.Empty),
+                                new XElement("tags", string.Empty),
                                 new XElement("comments", string.Empty)
                             ));
 
@@ -200,6 +229,12 @@ namespace Miniblog.Core.Services
             foreach (var category in post.Categories)
             {
                 categories.Add(new XElement("category", category));
+            }
+
+            var tags = doc.XPathSelectElement("post/tags");
+            foreach (var tag in post.Tags)
+            {
+                tags.Add(new XElement("tag", tag));
             }
 
             var comments = doc.XPathSelectElement("post/comments");
@@ -261,6 +296,18 @@ namespace Miniblog.Core.Services
 
             post.Categories.Clear();
             categories.Elements("category").Select(node => node.Value).ToList().ForEach(post.Categories.Add);
+        }
+
+        private static void LoadTags(Post post, XElement doc)
+        {
+            var tags = doc.Element("tags");
+            if (tags is null)
+            {
+                return;
+            }
+
+            post.Tags.Clear();
+            tags.Elements("tag").Select(node => node.Value).ToList().ForEach(post.Tags.Add);
         }
 
         private static void LoadComments(Post post, XElement doc)
@@ -342,6 +389,7 @@ namespace Miniblog.Core.Services
                 };
 
                 LoadCategories(post, doc);
+                LoadTags(post, doc);
                 LoadComments(post, doc);
                 this.cache.Add(post);
             }

--- a/src/Services/IBlogService.cs
+++ b/src/Services/IBlogService.cs
@@ -11,6 +11,8 @@ namespace Miniblog.Core.Services
 
         IAsyncEnumerable<string> GetCategories();
 
+        IAsyncEnumerable<string> GetTags();
+
         Task<Post?> GetPostById(string id);
 
         Task<Post?> GetPostBySlug(string slug);
@@ -20,6 +22,8 @@ namespace Miniblog.Core.Services
         IAsyncEnumerable<Post> GetPosts(int count, int skip = 0);
 
         IAsyncEnumerable<Post> GetPostsByCategory(string category);
+
+        IAsyncEnumerable<Post> GetPostsByTag(string tag);
 
         Task<string> SaveFile(byte[] bytes, string fileName, string? suffix = null);
 

--- a/src/Services/MetaWeblogService.cs
+++ b/src/Services/MetaWeblogService.cs
@@ -66,6 +66,7 @@ namespace Miniblog.Core.Services
             };
 
             post.categories.ToList().ForEach(newPost.Categories.Add);
+            post.mt_keywords.Split(',').ToList().ForEach(newPost.Tags.Add);
 
             if (post.dateCreated != DateTime.MinValue)
             {
@@ -123,6 +124,8 @@ namespace Miniblog.Core.Services
             existing.IsPublished = publish;
             existing.Categories.Clear();
             post.categories.ToList().ForEach(existing.Categories.Add);
+            existing.Tags.Clear();
+            post.mt_keywords.Split(',', StringSplitOptions.RemoveEmptyEntries).ToList().ForEach(existing.Tags.Add);
 
             if (post.dateCreated != DateTime.MinValue)
             {
@@ -173,6 +176,20 @@ namespace Miniblog.Core.Services
 
             return await this.blog.GetPosts(numberOfPosts)
                 .Select(this.ToMetaWebLogPost)
+                .ToArrayAsync();
+        }
+
+        public async Task<Tag[]> GetTagsAsync(string blogid, string username, string password)
+        {
+            this.ValidateUser(username, password);
+
+            return await this.blog.GetTags()
+                .Select(
+                    tag =>
+                        new Tag
+                        {
+                            name = tag
+                        })
                 .ToArrayAsync();
         }
 
@@ -231,7 +248,8 @@ namespace Miniblog.Core.Services
                 dateCreated = post.PubDate,
                 mt_excerpt = post.Excerpt,
                 description = post.Content,
-                categories = post.Categories.ToArray()
+                categories = post.Categories.ToArray(),
+                mt_keywords = string.Join(',', post.Tags)
             };
         }
 

--- a/src/Views/Blog/Edit.cshtml
+++ b/src/Views/Blog/Edit.cshtml
@@ -4,6 +4,7 @@
     ViewData[Constants.Title] = "Edit " + (Model.Title ?? "new post");
     var host = Context.Request.Host.ToString();
     var allCats = ViewData[Constants.AllCats] as List<string> ?? new List<string>();
+    var allTags = ViewData[Constants.AllTags] as List<string> ?? new List<string>();
 }
 
 @section Head {
@@ -32,6 +33,18 @@
             @foreach (var cat in allCats)
             {
                 <option value="@cat"/>
+            }
+            </datalist>
+        <br />
+
+        <label for="tags" class="label">Tags</label>
+        <input type="text" name="selecttag" id="selecttag" aria-describedby="desc_tags" list="taglist" placeholder="@string.Join(", ", Model.Tags)"  />
+        <input type="text" name="tags" id="tags" value="@string.Join(", ", Model.Tags)" hidden />
+        <span class="desc" id="desc_tags">Select, or build a comma separated list of keywords - to remove double the keyword</span>
+        <datalist id="taglist">
+            @foreach (var tag in allTags)
+            {
+                <option value="@tag"/>
             }
             </datalist>
         <br />

--- a/src/Views/Blog/Edit.cshtml
+++ b/src/Views/Blog/Edit.cshtml
@@ -1,4 +1,4 @@
-﻿@model Post
+@model Post
 @{
     var isNew = string.IsNullOrEmpty(Model.Title);
     ViewData[Constants.Title] = "Edit " + (Model.Title ?? "new post");
@@ -24,11 +24,11 @@
         <span class="desc" id="desc_slug">The part of the URL that identifies this blog post</span>
         <br />
 
-        <label for="categories" class="label">Tags</label>
-        <input type="text" name="selecttag" id="selecttag" aria-describedby="desc_categories" list="taglist" placeholder="@string.Join(", ", Model.Categories)"  />
+        <label for="categories" class="label">Categories</label>
+        <input type="text" name="selectcat" id="selectcat" aria-describedby="desc_categories" list="catlist" placeholder="@string.Join(", ", Model.Categories)"  />
         <input type="text" name="categories" id="categories" value="@string.Join(", ", Model.Categories)" hidden />
         <span class="desc" id="desc_categories">Select, or build a comma separated list of keywords - to remove double the keyword</span>
-        <datalist id="taglist">
+        <datalist id="catlist">
             @foreach (var cat in allCats)
             {
                 <option value="@cat"/>

--- a/src/Views/Blog/Post.cshtml
+++ b/src/Views/Blog/Post.cshtml
@@ -1,4 +1,4 @@
-﻿@model Post
+@model Post
 @inject IOptionsSnapshot<BlogSettings> settings
 @{
     ViewData[Constants.Title] = Model.Title;
@@ -33,29 +33,53 @@
         }
     </div>
 
-    <footer>
-        @if (Model.Categories.Any())
-        {
-            <ul class="categories">
-                <li> Posted in </li>
-                @foreach (string cat in Model.Categories)
-                {
-                    <li itemprop="articleSection"><a asp-controller="Blog" asp-action="Category" asp-route-category="@cat.ToLowerInvariant()" asp-route-page="">@cat</a></li>
-                }
-            </ul>
-        }
-        @if (settings.Value.DisplayComments)
-        {
-            <text>and has</text>
-            <a href="@Model.GetLink()#comments" itemprop="discussionUrl" title="Go to the comments section">
-                <span itemprop="commentCount">@Model.Comments.Count</span> @(Model.Comments.Count == 1 ? "comment" : "comments")
-            </a>
-        }
+	<footer>
+		@if (Model.Categories.Any())
+		{
+			<svg width="24" height="24" aria-hidden="true" role="img" aria-labelledby="_cats-@Model.ID" focusable="false" viewBox="0 0 24 24">
+				<title id="_cats-@Model.ID">Categories</title>
+				<path d="M10 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2h-8l-2-2z" fill="gray"></path>
+				<path d="M0 0h24v24H0z" fill="none"></path>
+			</svg>
+			<ul class="categories">
+				@foreach (string cat in Model.Categories)
+				{
+					<li itemprop="articleSection"><a asp-controller="Blog" asp-action="Category" asp-route-category="@cat.ToLowerInvariant()" asp-route-page="">@cat</a></li>
+				}
+			</ul>
+		}
 
-        <meta itemprop="author" content="@settings.Value.Owner" />
-        <meta itemprop="dateModified" content="@Model.LastModified.ToString("s")" />
-        <meta itemprop="mainEntityOfPage" content="@(host + Model.GetLink())" />
-    </footer>
+		@if (Model.Tags.Any())
+		{
+			<svg width="24" height="24" aria-hidden="true" role="img" aria-labelledby="_tags-@Model.ID" focusable="false" viewBox="0 0 24 24">
+				<title id="_tags-@Model.ID">Tags</title>
+				<path d="M21.41 11.58l-9-9C12.05 2.22 11.55 2 11 2H4c-1.1 0-2 .9-2 2v7c0 .55.22 1.05.59 1.42l9 9c.36.36.86.58 1.41.58.55 0 1.05-.22 1.41-.59l7-7c.37-.36.59-.86.59-1.41 0-.55-.23-1.06-.59-1.42zM5.5 7C4.67 7 4 6.33 4 5.5S4.67 4 5.5 4 7 4.67 7 5.5 6.33 7 5.5 7z" fill="gray"></path>
+				<path d="M0 0h24v24H0z" fill="none"></path>
+			</svg>
+			<ul class="tags">
+				@foreach (string tag in Model.Tags)
+				{
+					<li itemprop="articleSection"><a asp-controller="Blog" asp-action="Tag" asp-route-tag="@tag.ToLowerInvariant()" asp-route-page="">@tag</a></li>
+				}
+			</ul>
+		}
+
+		@if (settings.Value.DisplayComments)
+		{
+			<svg width="24" height="24" aria-hidden="true" role="img" aria-labelledby="_comments-@Model.ID" focusable="false" viewBox="0 0 24 24">
+				<title id="_comments-@Model.ID">Comments</title>
+				<path d="M21.99 4c0-1.1-.89-2-1.99-2H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h14l4 4-.01-18z" fill="gray"></path>
+				<path d="M0 0h24v24H0z" fill="none"></path>
+			</svg>
+			<a href="@Model.GetLink()#comments" itemprop="discussionUrl" title="Go to the comments section">
+				<span itemprop="commentCount">@Model.Comments.Count</span> @(Model.Comments.Count == 1 ? "comment" : "comments")
+			</a>
+		}
+
+		<meta itemprop="author" content="@settings.Value.Owner" />
+		<meta itemprop="dateModified" content="@Model.LastModified.ToString("s")" />
+		<meta itemprop="mainEntityOfPage" content="@(host + Model.GetLink())" />
+	</footer>
 </article>
 
 @if (showFullPost)

--- a/src/wwwroot/css/belowthefold.scss
+++ b/src/wwwroot/css/belowthefold.scss
@@ -50,15 +50,16 @@ noscript p {
     }
 }
 
-.categories {
+.categories, .tags {
     list-style: none;
     display: inline;
     padding: 0;
+    margin-right: 20px;
 
     li {
         display: inline-block;
 
-        &:not(:first-child):not(:last-child):after {
+        &:not(:last-child):after {
             content: ", ";
         }
     }

--- a/src/wwwroot/js/admin.js
+++ b/src/wwwroot/js/admin.js
@@ -119,15 +119,15 @@
         }
     }
 
-    // Tag input enhancement - using autocomplete input
-    var selecttag = document.getElementById("selecttag");
+    // Category input enhancement - using autocomplete input
+    var selectcat = document.getElementById("selectcat");
     var categories = document.getElementById("categories");
-    if (selecttag && categories) {
+    if (selectcat && categories) {
 
-        selecttag.onchange = function () {
+        selectcat.onchange = function () {
 
-            var phv = selecttag.placeholder;
-            var val = selecttag.value.toLowerCase();
+            var phv = selectcat.placeholder;
+            var val = selectcat.value.toLowerCase();
 
             var phv_array = phv.split(",").map(function (item) {
                 return removeEmpty(item);
@@ -151,9 +151,9 @@
                 }
             }
 
-            selecttag.placeholder = phv_array.join(", ");
-            categories.value = selecttag.placeholder;
-            selecttag.value = "";
+            selectcat.placeholder = phv_array.join(", ");
+            categories.value = selectcat.placeholder;
+            selectcat.value = "";
         };
     }
 

--- a/src/wwwroot/js/admin.js
+++ b/src/wwwroot/js/admin.js
@@ -157,4 +157,42 @@
         };
     }
 
+    // Tag input enhancement - using autocomplete input
+    var selecttag = document.getElementById("selecttag");
+    var tags = document.getElementById("tags");
+    if (selecttag && tags) {
+
+        selecttag.onchange = function () {
+
+            var phv = selecttag.placeholder;
+            var val = selecttag.value.toLowerCase();
+
+            var phv_array = phv.split(",").map(function (item) {
+                return removeEmpty(item);
+            });
+
+            var val_array = val.split(",").map(function (item) {
+                return removeEmpty(item);
+            });
+
+            for (var j = val_array.length - 1; j >= 0; j--) {
+                var v = val_array[j];
+                var flag = false;
+                for (var i = phv_array.length - 1; i >= 0; i--) {
+                    if (phv_array[i] === v) {
+                        phv_array.splice(i, 1);
+                        flag = true;
+                    }
+                }
+                if (!flag) {
+                    phv_array.push(v);
+                }
+            }
+
+            selecttag.placeholder = phv_array.join(", ");
+            tags.value = selecttag.placeholder;
+            selecttag.value = "";
+        };
+    }
+
 })();

--- a/src/wwwroot/wlwmanifest.xml
+++ b/src/wwwroot/wlwmanifest.xml
@@ -3,7 +3,7 @@
   <options>
     <clientType>Metaweblog</clientType>
     <supportsEmbeds>Yes</supportsEmbeds>
-    <supportsKeywords>No</supportsKeywords>
+    <supportsKeywords>Yes</supportsKeywords>
     <supportsNewCategories>Yes</supportsNewCategories>
     <supportsNewCategoriesInline>Yes</supportsNewCategoriesInline>
     <supportsCommentPolicy>No</supportsCommentPolicy>
@@ -12,7 +12,7 @@
     <supportsPages>No</supportsPages>
     <supportsPageParent>No</supportsPageParent>
     <supportsAuthor>No</supportsAuthor>
-    <supportsGetTags>No</supportsGetTags>
+    <supportsGetTags>Yes</supportsGetTags>
     <requiresHtmlTitles>No</requiresHtmlTitles>
     <supportsEmptyTitles>No</supportsEmptyTitles>
     <requiresXHTML>Yes</requiresXHTML>


### PR DESCRIPTION
This change adds support for tagging posts, beyond existing categorization that is already in place.

Tags are optional but can be used both though Open Live Writer and the built-in post editor.