### PR TITLE
Fix XML endpoints in RobotsController

### DIFF
--- a/src/Controllers/RobotsController.cs
+++ b/src/Controllers/RobotsController.cs
@@ -1,5 +1,6 @@
 namespace Miniblog.Core.Controllers
 {
+    using Microsoft.AspNetCore.Http.Features;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Options;
     using Microsoft.SyndicationFeed;
@@ -51,6 +52,8 @@ namespace Miniblog.Core.Controllers
         [Route("/rsd.xml")]
         public void RsdXml()
         {
+            EnableHttpBodySyncIO();
+
             var host = $"{this.Request.Scheme}://{this.Request.Host}";
 
             this.Response.ContentType = "application/xml";
@@ -83,6 +86,8 @@ namespace Miniblog.Core.Controllers
         [Route("/feed/{type}")]
         public async Task Rss(string type)
         {
+            EnableHttpBodySyncIO();
+
             this.Response.ContentType = "application/xml";
             var host = $"{this.Request.Scheme}://{this.Request.Host}";
 
@@ -126,6 +131,8 @@ namespace Miniblog.Core.Controllers
         [Route("/sitemap.xml")]
         public async Task SitemapXml()
         {
+            EnableHttpBodySyncIO();
+
             var host = $"{this.Request.Scheme}://{this.Request.Host}";
 
             this.Response.ContentType = "application/xml";
@@ -170,6 +177,12 @@ namespace Miniblog.Core.Controllers
             await atom.WriteGenerator("Miniblog.Core", "https://github.com/madskristensen/Miniblog.Core", "1.0").ConfigureAwait(false);
             await atom.WriteValue("updated", updated.ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture)).ConfigureAwait(false);
             return atom;
+        }
+
+        private void EnableHttpBodySyncIO()
+        {
+            var body = HttpContext.Features.Get<IHttpBodyControlFeature>();
+            body.AllowSynchronousIO = true;
         }
     }
 }


### PR DESCRIPTION
The XML endpoints (rsd, feed, sitemap), all of which uses a XmlWriter to produce a response, threw an exception:
InvalidOperationException: Synchronous operations are disallowed. Call WriteAsync or set AllowSynchronousIO to true instead.

According to https://github.com/dotnet/runtime/issues/42509, it's not possible to use XmlWriter asynchronously before .NET 5.0, so I set AllowSynchronousIO for those endpoints.