### PR TITLE
Add setting to force www prefix in address

### DIFF
--- a/src/Startup.cs
+++ b/src/Startup.cs
@@ -4,6 +4,7 @@ namespace Miniblog.Core
     using Microsoft.AspNetCore.Builder;
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Rewrite;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -68,6 +69,11 @@ namespace Miniblog.Core
             if (this.Configuration.GetValue<bool>("forcessl"))
             {
                 app.UseHttpsRedirection();
+            }
+
+            if (this.Configuration.GetValue<bool>("forceWwwPrefix"))
+            {
+                app.UseRewriter(new RewriteOptions().AddRedirectToWwwPermanent());
             }
 
             app.UseMetaWeblog("/metaweblog");

--- a/src/appsettings.Development.json
+++ b/src/appsettings.Development.json
@@ -1,4 +1,5 @@
 ﻿{
+  "forceWwwPrefix": false,
   "Logging": {
     "IncludeScopes": false,
     "LogLevel": {

--- a/src/appsettings.json
+++ b/src/appsettings.json
@@ -1,5 +1,6 @@
 {
   "forcessl": false,
+  "forceWwwPrefix": true,
   "user": {
     "username": "demo",
     // Generate a new password hash with salt here https://onlinehasher.azurewebsites.net/


### PR DESCRIPTION
It doesn't matter if you use www prefix or not as long as you pick one and stick with it. From what I've read it seems like allowing to use both variants could potentially affects SEO result. I would love to add forceWww setting to Miniblog.Core.